### PR TITLE
implement a simple log collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 
 data/**/*
+/logs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +31,17 @@ name = "anyhow"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -106,6 +126,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +209,19 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "error-code"
@@ -371,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +456,12 @@ checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "js-sys"
@@ -807,6 +872,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +953,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +1012,9 @@ name = "serde"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -934,6 +1025,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -953,8 +1055,14 @@ name = "shit-chat-says"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "crossbeam-channel",
+ "env_logger",
+ "log",
  "markov",
  "rustyline",
+ "serde",
+ "serde_json",
  "tokio",
  "twitch",
 ]
@@ -1001,6 +1109,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1090,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "twitch"
 version = "0.0.1"
-source = "git+https://github.com/jprochazk/twitch-rs.git#6793db565f2caca2de4cb537a40fd2d31761fa6e"
+source = "git+https://github.com/optimalstrategy/twitch-rs.git?branch=add-extendsub#f1c93c5f16489145365e221fb4918255695cbc62"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1112,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "twitch_getters"
 version = "0.0.1"
-source = "git+https://github.com/jprochazk/twitch-rs.git#6793db565f2caca2de4cb537a40fd2d31761fa6e"
+source = "git+https://github.com/optimalstrategy/twitch-rs.git?branch=add-extendsub#f1c93c5f16489145365e221fb4918255695cbc62"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1250,6 +1367,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,20 @@ path = "src/gen/main.rs"
 name = "bot"
 path = "src/bot/main.rs"
 
+[[bin]]
+name = "log-collector"
+path = "src/collector/main.rs"
+
+
 [dependencies]
 markov = "1.1.0"
 anyhow = "1.0.45"
 rustyline = "9.0.0"
 tokio = { verison = "1.13.0", features = ["full"] }
-twitch = { git = "https://github.com/jprochazk/twitch-rs.git" }
+twitch = { git = "https://github.com/optimalstrategy/twitch-rs.git", branch = "add-extendsub" }
+env_logger = "0.9.0"
+log = "0.4.14"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.69"
+chrono = "0.4.19"
+crossbeam-channel = "0.5.1"

--- a/src/collector/logger.rs
+++ b/src/collector/logger.rs
@@ -1,0 +1,110 @@
+use std::{
+  collections::HashMap,
+  io::{BufWriter, Write},
+};
+
+pub const BUF_SIZE_TO_FLUSH: usize = 1024; // 1KB
+
+pub struct ChatSink {
+  bytes_written: usize,
+  file: BufWriter<std::fs::File>,
+}
+
+pub struct ChatLogger {
+  queue: crossbeam_channel::Receiver<twitch::Privmsg>,
+  // No need to manually close the files, they are closed automatically on drop
+  current_date: chrono::Date<chrono::Utc>,
+  output_directory: std::path::PathBuf,
+  handles: HashMap<String, ChatSink>,
+}
+
+impl ChatLogger {
+  pub fn new(log_directory: std::path::PathBuf, queue: crossbeam_channel::Receiver<twitch::Privmsg>) -> Self {
+    Self {
+      queue,
+      output_directory: log_directory,
+      current_date: chrono::Utc::today(),
+      handles: HashMap::new(),
+    }
+  }
+
+  pub fn add_channels(&mut self, channels: Vec<String>) -> Result<(), anyhow::Error> {
+    for channel in channels {
+      self.rotate_log_file(&channel)?;
+    }
+    Ok(())
+  }
+
+  pub fn spawn_thread(mut self) -> std::thread::JoinHandle<Result<(), anyhow::Error>> {
+    std::thread::spawn(move || {
+      while let Ok(msg) = self.queue.recv() {
+        let now = chrono::Utc::today();
+        let date_has_changed = now.signed_duration_since(self.current_date).num_days() > 0;
+
+        let sink = match self.handles.get_mut(msg.channel()) {
+          None => self.rotate_log_file(msg.channel())?,
+          Some(_) if date_has_changed => self.rotate_log_file(msg.channel())?,
+          Some(handle) => handle,
+        };
+
+        Self::write(sink, msg.user.name.as_bytes())?;
+        Self::write(sink, b": ")?;
+        Self::write(sink, msg.text().as_bytes())?;
+        Self::write(sink, b"\n")?;
+
+        #[cfg(debug_assertions)]
+        log::info!("Logging a message in {} | buf={}", msg.channel(), sink.bytes_written);
+
+        if sink.bytes_written > BUF_SIZE_TO_FLUSH {
+          log::info!("Flushing {}b into the file in {}", sink.bytes_written, msg.channel());
+
+          sink.file.flush()?;
+          sink.bytes_written = 0;
+        }
+      }
+
+      log::info!("Failed to recv from the queue, stopping the logger thread.");
+      Ok(())
+    })
+  }
+
+  fn rotate_log_file(&mut self, channel: &str) -> Result<&mut ChatSink, anyhow::Error> {
+    let directory = self.output_directory.join(channel);
+    let path = directory.join(format!("{channel}-{}.log", self.current_date));
+
+    if !directory.exists() {
+      std::fs::create_dir_all(&directory)?;
+    }
+
+    let sink = if self.handles.contains_key(channel) {
+      // This is to convince the borrow checker
+      let sink = self.handles.get_mut(channel).unwrap();
+      *sink = Self::open(&path)?;
+      sink
+    } else {
+      self.handles.insert(channel.to_owned(), Self::open(&path)?);
+      self.handles.get_mut(channel).unwrap()
+    };
+
+    log::info!("Writing to {}", path.display());
+
+    Ok(sink)
+  }
+
+  fn open(path: &std::path::Path) -> Result<ChatSink, std::io::Error> {
+    std::fs::OpenOptions::new()
+      .create(true)
+      .append(true)
+      .open(path)
+      .map(|file| ChatSink {
+        bytes_written: 0,
+        file: BufWriter::new(file),
+      })
+  }
+
+  #[inline]
+  fn write(sink: &mut ChatSink, bytes: &[u8]) -> Result<(), std::io::Error> {
+    sink.bytes_written += bytes.len();
+    sink.file.write_all(bytes)
+  }
+}

--- a/src/collector/main.rs
+++ b/src/collector/main.rs
@@ -50,7 +50,7 @@ async fn run(config: CollectorConfig) -> Result<(), anyhow::Error> {
                 _ => ()
             },
             Err(err) => {
-                panic!("{}", err);
+                log::error!("{}", err);
             }
         }
     }

--- a/src/collector/main.rs
+++ b/src/collector/main.rs
@@ -1,0 +1,102 @@
+#![feature(format_args_capture)]
+use twitch::{Config, Message};
+
+pub mod logger;
+
+pub const DEFAULT_CONFIG_PATH: &str = "./collector.json";
+pub const DEFAULT_OUTPUT_DIRECTORY: &str = "./logs";
+
+pub fn default_output_directory() -> std::path::PathBuf {
+  std::path::PathBuf::from(DEFAULT_OUTPUT_DIRECTORY)
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CollectorConfig {
+  channels: Vec<String>,
+  #[serde(default = "default_output_directory")]
+  output_directory: std::path::PathBuf,
+}
+
+async fn run(config: CollectorConfig) -> Result<(), anyhow::Error> {
+  // QQQ: ingest from multiple threads?
+  // QQQ: do we want multiple writers as well? If we do, do we want to lock on write or split the channels between N internally-synchronized threads?
+  let mut conn = twitch::connect(Config::default()).await.unwrap();
+
+  for channel in &config.channels {
+    log::info!("Joining {channel}");
+    conn.sender.join(channel).await?;
+  }
+
+  let (tx, rx) = crossbeam_channel::unbounded();
+  let mut logger = logger::ChatLogger::new(config.output_directory, rx);
+  logger.add_channels(config.channels)?;
+  let _handle = logger.spawn_thread();
+
+  loop {
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            log::info!("CTRL-C");
+            break;
+        },
+        result = conn.reader.next() => match result {
+            Ok(message) => match message {
+                Message::Ping(ping) => conn.sender.pong(ping.arg()).await.unwrap(),
+                Message::Privmsg(message) => {
+                    if let Err(e) = tx.try_send(message) {
+                        log::error!("The writer thread must have panicked as its queue is unavailable: {e}. Shutting down the listener.");
+                        break;
+                    }
+                },
+                _ => ()
+            },
+            Err(err) => {
+                panic!("{}", err);
+            }
+        }
+    }
+  }
+
+  Ok(())
+}
+
+pub fn main() -> Result<(), anyhow::Error> {
+  env_logger::init();
+
+  let path = std::env::args().nth(1);
+  let path = path.as_ref().map(|s| &s[..]).unwrap_or(DEFAULT_CONFIG_PATH);
+  let path = std::path::Path::new(path);
+
+  let config = match std::fs::read_to_string(path) {
+    Ok(s) => serde_json::from_str(&s)?,
+    Err(_) => {
+      log::warn!("Couldn't read the config file, falling back to the default one.");
+      CollectorConfig {
+        channels: vec!["moscowwbish".to_string(), "ambadev".to_string()],
+        output_directory: default_output_directory(),
+      }
+    }
+  };
+
+  if config.channels.is_empty() {
+    log::error!("No channels specified in the config file, exiting.");
+    anyhow::bail!("No channel specified");
+  }
+
+  if !config.output_directory.exists() {
+    log::info!("Creating the output directory...");
+    std::fs::create_dir_all(&config.output_directory)?;
+  }
+
+  if !config.output_directory.is_dir() {
+    log::error!("The config directory is not a directory.");
+    anyhow::bail!(format!("{} is not a directory", config.output_directory.display()));
+  }
+
+  log::info!("Using this config: {config:?}");
+
+  tokio::runtime::Builder::new_multi_thread()
+    .enable_all()
+    .build()
+    .unwrap()
+    .block_on(run(config))
+}


### PR DESCRIPTION
- Single ingestion thread, single writer thread. Received messages get pushed onto the queue consumed by the writer thread.
- Every channel gets its own log file with an always open file descriptor, configured to buffer up to 1KB of text, after which an actual filesystem write occurs.
- Every 24 hours (UTC), the open log files get rotated.
- The bot easily consumes around 60k concurrent viewers, haven't tested with more.
    - Note that it appears that the bot gets shadow-rate-limited by twitch in large channels (~100k active viewers), so we might need to deploy with credentials.
    - If we need more throughput, we could have multiple listener and writer threads, but that'll obviously complicate the setup.
        - With multiple listener threads, message writes won't be locally sequentially consistent, so we'll need a sorting step at some point if we care about that.
        - With multiple writer threads, we'll need to figure out how to share the file descriptors. An obvious solution is to wrap every FD with a lock. Alternatively, the file descriptors could be evenly split between N threads, but that won't account for channel sizes (2 huge channels could end up on the same thread, while 3 tiny channels get parked onto a different thread).
        - The above approaches combined?
    - 4Head throughput solution: run multiple docker containers with different input channels (biggest bottleneck is IO, so we aren't hard limited by the number of cores)
- No log cleaning has been implemented yet.