### PR TITLE
upgrade bugfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,7 +3107,7 @@ dependencies = [
 
 [[package]]
 name = "shit-chat-says"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,7 +3263,7 @@ dependencies = [
  "thiserror",
  "tokio-stream",
  "url",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "whoami",
 ]
 
@@ -3294,7 +3294,7 @@ checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
 dependencies = [
  "once_cell",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -3623,6 +3623,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.2",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3643,7 +3653,9 @@ dependencies = [
  "log",
  "rustls 0.21.2",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tungstenite",
+ "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -3715,10 +3727,12 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.21.2",
  "sha1",
  "thiserror",
  "url",
  "utf-8",
+ "webpki",
 ]
 
 [[package]]
@@ -3969,6 +3983,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,6 @@ itertools = "0.11.0"
 humantime-serde = "1.1.1"
 futures = "0.3.28"
 structopt = "0.3.26"
-tokio-tungstenite = { version = "0.19.0", features = ["rustls"] }
+tokio-tungstenite = { version = "0.19.0", features = [
+  "rustls-tls-webpki-roots",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shit-chat-says"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/chat/main.rs
+++ b/src/chat/main.rs
@@ -11,6 +11,7 @@ use std::{
   time::{Duration, Instant},
 };
 use twitch::Command;
+use twitch_api::SuggestedAction;
 
 // Set to 0 to disable sampling.
 const MAX_SAMPLES: usize = 4;
@@ -128,7 +129,6 @@ async fn run(config: Config) -> Result<()> {
   'stop: loop {
     log::info!("Connecting to Twitch");
     let mut conn = twitch_api::TwitchStream::new().await?;
-    let mut error_count = 0;
 
     let mut reply_times = std::collections::HashMap::with_capacity(state.config.channels.len());
     for channel in &state.config.channels {
@@ -153,38 +153,64 @@ async fn run(config: Config) -> Result<()> {
         },
         result = conn.receive() => match result {
           Ok(Some(batch)) => {
-              for twitch_msg in batch.lines().map(twitch::Message::parse).filter_map(Result::ok) {
-                match twitch_msg.command() {
-                  Command::Ping => conn.pong().await?,
-                  Command::Reconnect => conn.reconnect(&state.credentials, &state.config.channels).await?,
-                  Command::Privmsg => {
-                    let channel = twitch_msg.channel().unwrap_or("???");
-                    let login = twitch_msg.prefix().and_then(|v| v.nick).unwrap_or("???");
-                    let text = twitch_msg.text().unwrap_or("???").trim();
-                    let badges = twitch_msg.tag(twitch::Tag::Badges).unwrap_or("");
-
-                    handle_message(&mut conn, &mut state, channel.strip_prefix('#').unwrap_or(channel), MessageUser {
-                      login,
-                      badges
-                    }, text).await?;
-                  },
-                  _ => (),
-                }
+            if let Err(e) = handle_messages(&mut conn, &mut state, batch).await {
+              let action = SuggestedAction::from(&e);
+              log::error!("Error processing messages: {e}. Action = {action}");
+              match action {
+                SuggestedAction::KeepGoing => continue,
+                SuggestedAction::Reconnect => break,
+                SuggestedAction::Terminate => break 'stop Err(anyhow::anyhow!(e)),
               }
+            }
           },
-          Ok(_) => (),
+          Ok(None) => break,
           Err(e) => {
-            log::error!("Error receiving messages: {}", e);
-            error_count += 1;
-            if error_count > 5 {
-              log::error!("Too many receive errors, reconnecting");
-              break;
+            let action = SuggestedAction::from(&e);
+            log::error!("Error receiving messages: {e}. Action = {action}");
+            match action {
+              SuggestedAction::KeepGoing => continue,
+              SuggestedAction::Reconnect => break,
+              SuggestedAction::Terminate => break 'stop Err(anyhow::anyhow!(e)),
             }
           }
         }
       }
     }
   }
+}
+
+async fn handle_messages(
+  conn: &mut twitch_api::TwitchStream,
+  state: &mut State,
+  batch: String,
+) -> std::result::Result<(), twitch_api::WsError> {
+  for twitch_msg in batch.lines().map(twitch::Message::parse).filter_map(Result::ok) {
+    match twitch_msg.command() {
+      Command::Ping => conn.pong().await?,
+      Command::Reconnect => conn.reconnect(&state.credentials, &state.config.channels).await?,
+      Command::Notice => {
+        let text = twitch_msg.text().unwrap_or("???").trim();
+        log::info!("Notice: {}", text);
+      }
+      Command::Privmsg => {
+        let channel = twitch_msg.channel().unwrap_or("???");
+        let login = twitch_msg.prefix().and_then(|v| v.nick).unwrap_or("???");
+        let text = twitch_msg.text().unwrap_or("???").trim();
+        let badges = twitch_msg.tag(twitch::Tag::Badges).unwrap_or("");
+
+        handle_message(
+          conn,
+          state,
+          channel.strip_prefix('#').unwrap_or(channel),
+          MessageUser { login, badges },
+          text,
+        )
+        .await?;
+      }
+      _ => (),
+    }
+  }
+  Ok(())
 }
 
 struct MessageUser<'a> {
@@ -210,7 +236,7 @@ async fn handle_message(
   channel: &str,
   user: MessageUser<'_>,
   text: &str,
-) -> Result<()> {
+) -> std::result::Result<(), twitch_api::WsError> {
   log::info!("[{channel}] {}: {text}", user.login);
 
   // format: `@LOGIN <seed> <...rest>`

--- a/src/twitch_api/lib.rs
+++ b/src/twitch_api/lib.rs
@@ -30,7 +30,7 @@ pub struct TwitchStream {
 
 impl TwitchStream {
   pub async fn new() -> Result<Self, WsError> {
-    Self::with_uri("ws://irc-ws.chat.twitch.tv:80").await
+    Self::with_uri("wss://irc-ws.chat.twitch.tv:443").await
   }
 
   pub async fn with_uri(uri: impl Into<String>) -> Result<Self, WsError> {


### PR DESCRIPTION
* fix: correctly handle websocket errors: ignore, reconnect, or quit when necessary
* feat: follow the JOIN rate limits
  - This is done by spawning a tokio task with a [`tokio::interval`](https://docs.rs/tokio/latest/tokio/time/fn.interval.html), sending batches of 20 channels to a tokio channel
  - The `receive()` method now has a mini-select between the join tokio channel and the websocket stream. 
  - It's kind of messy, but it's the best way I could  while still using a websocket. Would work much better with a split read/write tcp stream
    ```rs
    let (reader, writer) = tcp_stream();
    let (tx, rx) = channel();

    // send messages to twitch
    spawn(async move {
      while let Some(msg) = rx.recv().await {
        writer.send(msg).await;
      }
    });

    // send JOIN messages to the writer every 10 seconds
    spawn(async move {
      let interval = time::interval(10 seconds);
      for batch in channels.chunks(20) {
        interval.tick().await;
        tx.send("JOIN {batch.join(',')}");
      }
    })

    // handle incoming twitch messages & send responses to the writer half
    while let Some(twitch_msg) = reader.next().await {
      match twitch_msg {
        Ping => tx.send("PONG"),
        Prvimsg => tx.send(handle_message(twitch_msg)),       
      }
    }
    ```